### PR TITLE
Couple fixes to src mass example

### DIFF
--- a/tutorial/inference_6_advanced_config_settings/bbh_example-src_masses.ini
+++ b/tutorial/inference_6_advanced_config_settings/bbh_example-src_masses.ini
@@ -1,7 +1,6 @@
 [model]
 name = gaussian_noise
-h1-low-frequency-cutoff = 20
-l1-low-frequency-cutoff = 20
+low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt
@@ -123,9 +122,9 @@ mass2 = srcmass2 * (1 + redshift(distance))
 [sampling_params]
 ; parameters on the left will be sampled in
 ; parametes on the right
-mass1, mass2 : mchirp, q
+srcmass1, srcmass2 = mchirp, q
 
 [sampling_transforms-mchirp+q]
-; inputs mass1, mass2
-; outputs mchirp, q
 name = mass1_mass2_to_mchirp_q
+mass1_param = srcmass1
+mass2_param = srcmass2


### PR DESCRIPTION
Updates the low-frequency-cutoff to the current format, and fixes the sampling transform in the srcmass example.