### PR TITLE
Update inference_8_BHRingdown.ipynb

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/tutorial/inference_8_BHRingdown.ipynb
+++ b/tutorial/inference_8_BHRingdown.ipynb
@@ -342,7 +342,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pycbc_inference --verbose \\\n",
+    "!timeout 300 \\\n"
+    "    pycbc_inference --verbose \\\n",
     "    --config-files model.ini data.ini prior.ini sampler.ini \\\n",
     "    --output-file inference.hdf \\\n",
     "    --seed {seed} \\\n",

--- a/tutorial/inference_8_BHRingdown.ipynb
+++ b/tutorial/inference_8_BHRingdown.ipynb
@@ -342,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!timeout 300 \\\n"
+    "!timeout 300 \\\n",
     "    pycbc_inference --verbose \\\n",
     "    --config-files model.ini data.ini prior.ini sampler.ini \\\n",
     "    --output-file inference.hdf \\\n",


### PR DESCRIPTION
Set timeout so notebook can be run without intervention. 

This adds a timeout to the manually pycbc inference run so it is automatically shut down eventually. It can of course still be manually interrupted earlier as  normally done when you run a tutorial session with this notebook.  

This PR will hopefully test that the timeout time  is sufficient for the unittests.  