### PR TITLE
Add installs so inference 9 will work in Google colab

### DIFF
--- a/tutorial/inference_9_AddingCustomModels.ipynb
+++ b/tutorial/inference_9_AddingCustomModels.ipynb
@@ -105,8 +105,8 @@
    "source": [
     "import sys\n",
     "!{sys.executable} -m pip install pycbc --no-cache-dir\n",
-    "# we'll also need the epsie sampler, which is not installed by default\n",
-    "!{sys.executable} -m pip install epsie"
+    "# we'll also need the ptemcee and epsie samplers, which are not installed by default\n",
+    "!{sys.executable} -m pip install \"emcee==2.2.1\" ptemcee epsie"
    ]
   },
   {


### PR DESCRIPTION
Installs emcee and ptemcee so inference 9 tutorial will work in google colab 